### PR TITLE
browser: set security state even if user disable security alerts

### DIFF
--- a/src/com/android/browser/Tab.java
+++ b/src/com/android/browser/Tab.java
@@ -574,6 +574,7 @@ class Tab implements PictureListener {
                     .show();
             } else {
                 handler.proceed();
+                handleProceededAfterSslError(error);
             }
         }
 


### PR DESCRIPTION
Even if a user disabled the security alerts (ssl errors), the security state
 SHOULD be set to shown that the certificate
has a problem. Actually, the certificate is reported as valid, which is
 complety wrong.

Change-Id: I9d8647f2a6dba2b9387b240b5511df18e1b4ea22
JIRA: NIGHTLIES-813
Signed-off-by: Jorge Ruesga <jorge@ruesga.com>